### PR TITLE
Add video media support and improve text input handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>Quiz Maker — full build (fixed)</title>
+<title>Quiz Maker ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ full build (fixed)</title>
 <style>
   :root{--bg:#f4faff;--card:#fff;--ink:#163046;--muted:#5e7180;--line:#d6e2ea;--accent:#2e7d32}
   body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;margin:0;background:var(--bg);color:var(--ink)}
@@ -44,7 +44,7 @@
 </head>
 <body>
 <main>
-  <h1>📚 Quiz Maker</h1>
+  <h1>ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ Quiz Maker</h1>
   <div class="tabs">
     <button id="tab-editor"></button>
     <button id="tab-player"></button>
@@ -53,7 +53,7 @@
 
   <section id="editor" class="tab-content">
     <h2 id="editorTitle">Edit Questions</h2>
-    <button id="newQuestion" class="btn">➕ New question</button>
+    <button id="newQuestion" class="btn">ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ New question</button>
 
     <div id="editorForm" style="display:none">
       <label id="questionLabel">Question</label>
@@ -61,12 +61,16 @@
       <div class="row" id="qMediaRow">
         <input type="file" id="qImg" accept="image/*" style="display:none"/>
         <input type="file" id="qAud" accept="audio/*" style="display:none"/>
-        <button id="qImgPick" class="chip" type="button">🖼️ Image</button>
+        <button id="qImgPick" class="chip" type="button">ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¼ÃÂÃÂÃÂÃÂ¯ÃÂÃÂÃÂÃÂ¸ÃÂÃÂÃÂÃÂ Image</button>
         <img id="qImgPrev" class="thumb" style="display:none"/>
         <button id="qImgClear" class="btn" type="button" style="display:none">Clear image</button>
-        <button id="qAudPick" class="chip" type="button">🔈 Audio</button>
+        <button id="qAudPick" class="chip" type="button">ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ Audio</button>
         <span id="qAudMini" style="display:none"></span>
         <button id="qAudClear" class="btn" type="button" style="display:none">Clear audio</button>
+        <input type="file" id="qVid" accept="video/*" style="display:none"/>
+        <button id="qVidPick" class="chip" type="button">ÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂ¹ Video</button>
+        <span id="qVidMini" style="display:none"></span>
+        <button id="qVidClear" class="btn" type="button" style="display:none">Clear video</button>
       </div>
 
       <label id="questionTypeLabel">Type</label>
@@ -86,19 +90,23 @@
       <div class="row" id="cMediaRow">
         <input type="file" id="cImg" accept="image/*" style="display:none"/>
         <input type="file" id="cAud" accept="audio/*" style="display:none"/>
-        <button id="cImgPick" class="chip" type="button">🖼️ Image</button>
+        <button id="cImgPick" class="chip" type="button">ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¼ÃÂÃÂÃÂÃÂ¯ÃÂÃÂÃÂÃÂ¸ÃÂÃÂÃÂÃÂ Image</button>
         <img id="cImgPrev" class="thumb" style="display:none"/>
         <button id="cImgClear" class="btn" type="button" style="display:none">Clear image</button>
-        <button id="cAudPick" class="chip" type="button">🔈 Audio</button>
+        <button id="cAudPick" class="chip" type="button">ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ Audio</button>
         <span id="cAudMini" style="display:none"></span>
         <button id="cAudClear" class="btn" type="button" style="display:none">Clear audio</button>
+        <input type="file" id="cVid" accept="video/*" style="display:none"/>
+        <button id="cVidPick" class="chip" type="button">ÃÂ°ÃÂÃÂÃÂ¹ Video</button>
+        <span id="cVidMini" style="display:none"></span>
+        <button id="cVidClear" class="btn" type="button" style="display:none">Clear video</button>
       </div>
 
       <label id="categoryLabel">Category / Topic (optional)</label>
-      <select id="categorySelect"><option id="catNoneOption" value="">— none —</option></select>
+      <select id="categorySelect"><option id="catNoneOption" value="">ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ none ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ</option></select>
       <div id="categoryNewUI" style="display:none;margin-top:8px"></div>
 
-      <button id="saveQuestion" class="btn btn-primary">💾 Save question</button>
+      <button id="saveQuestion" class="btn btn-primary">ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¾ Save question</button>
       <button id="cancelEdit" class="btn" type="button">Cancel</button>
     </div>
 
@@ -107,8 +115,8 @@
 
     <div class="row" style="margin-top:10px">
       <input type="file" id="importFile" accept="application/json" style="display:none"/>
-      <button id="importBtn" class="btn">📂 Import JSON</button>
-      <button id="exportBtn" class="btn btn-primary">💾 Export JSON</button>
+      <button id="importBtn" class="btn">ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ Import JSON</button>
+      <button id="exportBtn" class="btn btn-primary">ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¾ Export JSON</button>
     </div>
   </section>
 
@@ -170,7 +178,7 @@
     <div id="catsPanel"><div id="catsManager"></div></div>
 
     <button id="saveSettings" class="btn btn-primary">Save settings</button>
-    <span id="settingsSaved" style="display:none;margin-left:8px">Saved ✓</span>
+    <span id="settingsSaved" style="display:none;margin-left:8px">Saved ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ</span>
   </section>
 </main>
 
@@ -201,24 +209,26 @@ if('feedback' in settings){
 document.documentElement.lang = settings.lang || 'en';
 const STRINGS={
   en:{submit:'Submit',next:'Next',skip:'Skip',correct:'Correct',wrong:'Wrong',time:'Time\'s up!',score:'Score',answers:'Answers',goodguess:'Good guess!'},
-  de:{submit:'Senden',next:'Weiter',skip:'Überspringen',correct:'Richtig',wrong:'Falsch',time:'Zeit abgelaufen!',score:'Punkte',answers:'Antworten',goodguess:'Guter Tipp!'}
+  de:{submit:'Senden',next:'Weiter',skip:'ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂberspringen',correct:'Richtig',wrong:'Falsch',time:'Zeit abgelaufen!',score:'Punkte',answers:'Antworten',goodguess:'Guter Tipp!'}
 };
 function t(k){ const lang=settings.lang||'en'; return (STRINGS[lang]&&STRINGS[lang][k])||STRINGS.en[k]||k; }
 
 function applyLang(){
   const lang=settings.lang||'en';
   const tx={
-    'tab-editor': lang==='de'?'✏️ Editor':'✏️ Editor',
-    'tab-player': lang==='de'?'▶️ Spielen':'▶️ Play',
-    'tab-settings': lang==='de'?'⚙️ Einstellungen':'⚙️ Settings',
+    'tab-editor': lang==='de'?'ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¯ÃÂÃÂÃÂÃÂ¸ÃÂÃÂÃÂÃÂ Editor':'ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¯ÃÂÃÂÃÂÃÂ¸ÃÂÃÂÃÂÃÂ Editor',
+    'tab-player': lang==='de'?'ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¶ÃÂÃÂÃÂÃÂ¯ÃÂÃÂÃÂÃÂ¸ÃÂÃÂÃÂÃÂ Spielen':'ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¶ÃÂÃÂÃÂÃÂ¯ÃÂÃÂÃÂÃÂ¸ÃÂÃÂÃÂÃÂ Play',
+    'tab-settings': lang==='de'?'ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¯ÃÂÃÂÃÂÃÂ¸ÃÂÃÂÃÂÃÂ Einstellungen':'ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¯ÃÂÃÂÃÂÃÂ¸ÃÂÃÂÃÂÃÂ Settings',
     'editorTitle': lang==='de'?'Fragen bearbeiten':'Edit Questions',
-    'newQuestion': lang==='de'?'➕ Neue Frage':'➕ New question',
+    'newQuestion': lang==='de'?'ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ Neue Frage':'ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ New question',
     'questionLabel': lang==='de'?'Frage':'Question',
     'questionText': {placeholder: lang==='de'?'Gib deine Frage ein':'Type your question'},
-    'qImgPick': lang==='de'?'🖼️ Bild':'🖼️ Image',
-    'qImgClear': lang==='de'?'Bild löschen':'Clear image',
-    'qAudPick': lang==='de'?'🔈 Audio':'🔈 Audio',
-    'qAudClear': lang==='de'?'Audio löschen':'Clear audio',
+    'qImgPick': lang==='de'?'ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¼ÃÂÃÂÃÂÃÂ¯ÃÂÃÂÃÂÃÂ¸ÃÂÃÂÃÂÃÂ Bild':'ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¼ÃÂÃÂÃÂÃÂ¯ÃÂÃÂÃÂÃÂ¸ÃÂÃÂÃÂÃÂ Image',
+    'qImgClear': lang==='de'?'Bild lÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¶schen':'Clear image',
+    'qAudPick': lang==='de'?'ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ Audio':'ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ Audio',
+    'qAudClear': lang==='de'?'Audio lÃ¶schen':'Clear audio',
+    'qVidPick': lang==='de'?'ð¹ Video':'ð¹ Video',
+    'qVidClear': lang==='de'?'Video lÃ¶schen':'Clear video',
     'questionTypeLabel': lang==='de'?'Typ':'Type',
     'questionTypeSingle': lang==='de'?'Einzelauswahl':'Single Choice',
     'questionTypeMultiple': lang==='de'?'Mehrfachauswahl':'Multiple Choice',
@@ -228,17 +238,19 @@ function applyLang(){
     'questionTypeOrder': lang==='de'?'In die richtige Reihenfolge bringen':'Put in the right order',
     'commentLabel': lang==='de'?'Kommentar (optional)':'Comment (optional)',
     'questionComment': {placeholder: lang==='de'?'Wird bei Feedback angezeigt, wenn aktiviert':'Shown with feedback when enabled'},
-    'cImgPick': lang==='de'?'🖼️ Bild':'🖼️ Image',
-    'cImgClear': lang==='de'?'Bild löschen':'Clear image',
-    'cAudPick': lang==='de'?'🔈 Audio':'🔈 Audio',
+    'cImgPick': lang==='de'?'ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¼ÃÂÃÂÃÂÃÂ¯ÃÂÃÂÃÂÃÂ¸ÃÂÃÂÃÂÃÂ Bild':'ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¼ÃÂÃÂÃÂÃÂ¯ÃÂÃÂÃÂÃÂ¸ÃÂÃÂÃÂÃÂ Image',
+    'cImgClear': lang==='de'?'Bild lÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¶schen':'Clear image',
+    'cAudPick': lang==='de'?'ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ Audio':'ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ Audio',
     'cAudClear': lang==='de'?'Audio löschen':'Clear audio',
+    'cVidPick': lang==='de'?'📹 Video':'📹 Video',
+    'cVidClear': lang==='de'?'Video löschen':'Clear video',
     'categoryLabel': lang==='de'?'Kategorie / Thema (optional)':'Category / Topic (optional)',
-    'catNoneOption': lang==='de'?'— keine —':'— none —',
-    'saveQuestion': lang==='de'?'💾 Frage speichern':'💾 Save question',
+    'catNoneOption': lang==='de'?'ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ keine ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ':'ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ none ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ',
+    'saveQuestion': lang==='de'?'ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¾ Frage speichern':'ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¾ Save question',
     'cancelEdit': lang==='de'?'Abbrechen':'Cancel',
     'savedQuestionsTitle': lang==='de'?'Gespeicherte Fragen':'Saved Questions',
-    'importBtn': lang==='de'?'📂 JSON importieren':'📂 Import JSON',
-    'exportBtn': lang==='de'?'💾 JSON exportieren':'💾 Export JSON',
+    'importBtn': lang==='de'?'ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ JSON importieren':'ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ Import JSON',
+    'exportBtn': lang==='de'?'ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¾ JSON exportieren':'ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¾ Export JSON',
     'playerTitle': lang==='de'?'Quiz-Zeit':'Quiz Time',
     'settingsTitle': lang==='de'?'Einstellungen':'Settings',
     'themeLabel': lang==='de'?'Design ':'Theme ',
@@ -253,14 +265,14 @@ function applyLang(){
     'showCommentsLabel': lang==='de'?'Kommentare anzeigen':'Show comments',
     'linkifyCommentsLabel': lang==='de'?'Links in Kommentaren aktivieren':'Linkify comment URLs',
     'validationHeading': lang==='de'?'Validierung':'Validation',
-    'autoValidateLabel': lang==='de'?'Automatisch prüfen (Standard)':'Validate automatically (default)',
+    'autoValidateLabel': lang==='de'?'Automatisch prÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¼fen (Standard)':'Validate automatically (default)',
     'randomHeading': lang==='de'?'Zufallsmodus':'Random mode',
-    'randomModeLabel': lang==='de'?'Fragen zufällig anordnen':'Randomize questions',
+    'randomModeLabel': lang==='de'?'Fragen zufÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¤llig anordnen':'Randomize questions',
     'randomCountLabel': lang==='de'?'Anzahl der Fragen ':'Number of questions ',
     'timeHeading': lang==='de'?'Zeitlimit':'Time Limit',
     'timeLimitLabel': lang==='de'?'Zeit (Sekunden) ':'Time (seconds) ',
     'textMatchHeading': lang==='de'?'Textabgleich':'Text Matching',
-    'caseSensitiveLabel': lang==='de'?'Groß-/Kleinschreibung beachten':'Case sensitive',
+    'caseSensitiveLabel': lang==='de'?'GroÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ-/Kleinschreibung beachten':'Case sensitive',
     'ignorePunctLabel': lang==='de'?'Satzzeichen ignorieren':'Ignore punctuation',
     'normalizeAccentsLabel': lang==='de'?'Akzente normalisieren':'Normalize accents',
     'ignoreSpacesLabel': lang==='de'?'Leerzeichen zusammenfassen':'Collapse spaces',
@@ -270,14 +282,14 @@ function applyLang(){
     'mcq_partial': lang==='de'?'Teilpunkte':'Partial credit',
     'mcq_partial_penalty': lang==='de'?'Teilpunkte mit Abzug':'Partial with penalty',
     'speechHeading': lang==='de'?'Sprachausgabe':'Speech',
-    'autoTTSQuestionsLabel': lang==='de'?'Automatische TTS für Fragen':'Auto-TTS questions',
-    'autoTTSItemsLabel': lang==='de'?'Automatische TTS für Elemente/Optionen':'Auto-TTS items/options',
+    'autoTTSQuestionsLabel': lang==='de'?'Automatische TTS fÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¼r Fragen':'Auto-TTS questions',
+    'autoTTSItemsLabel': lang==='de'?'Automatische TTS fÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¼r Elemente/Optionen':'Auto-TTS items/options',
     'playModeHeading': lang==='de'?'Spielmodus':'Play mode',
-    'showCategoryLabel': lang==='de'?'Kategorie während des Spiels anzeigen':'Show category during play',
-    'allowSkipLabel': lang==='de'?'Überspringen von Fragen erlauben':'Allow skipping questions',
+    'showCategoryLabel': lang==='de'?'Kategorie wÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¤hrend des Spiels anzeigen':'Show category during play',
+    'allowSkipLabel': lang==='de'?'ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂberspringen von Fragen erlauben':'Allow skipping questions',
     'catsToggle': lang==='de'?'Kategorien / Themen / Mottos':'Categories / Topics / Mottos',
     'saveSettings': lang==='de'?'Einstellungen speichern':'Save settings',
-    'settingsSaved': lang==='de'?'Gespeichert ✓':'Saved ✓'
+    'settingsSaved': lang==='de'?'Gespeichert ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ':'Saved ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ'
   };
   const specials={
     themeLabel:tx.themeLabel,
@@ -350,28 +362,38 @@ function normalizeText(s){
   return out;
 }
 const fileToDataURL=f=>new Promise((res,rej)=>{const r=new FileReader(); r.onload=()=>res(r.result); r.onerror=rej; r.readAsDataURL(f);});
-function miniAudio(url,label='Play'){ const b=document.createElement('button'); b.className='chip'; b.setAttribute('aria-pressed','false'); b.textContent='🔈 '+label; const a=new Audio(url); b.onclick=()=>{ if(b.getAttribute('aria-pressed')==='true'){ a.pause(); a.currentTime=0; b.setAttribute('aria-pressed','false'); } else { a.play().catch(()=>{}); b.setAttribute('aria-pressed','true'); a.onended=()=>b.setAttribute('aria-pressed','false'); } }; return b; }
+function miniAudio(url,label='Play'){ const b=document.createElement('button'); b.className='chip'; b.setAttribute('aria-pressed','false'); b.textContent='ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ '+label; const a=new Audio(url); b.onclick=()=>{ if(b.getAttribute('aria-pressed')==='true'){ a.pause(); a.currentTime=0; b.setAttribute('aria-pressed','false'); } else { a.play().catch(()=>{}); b.setAttribute('aria-pressed','true'); a.onended=()=>b.setAttribute('aria-pressed','false'); } }; return b; }
 function miniVideo(url){ const v=document.createElement('video'); v.src=url; v.controls=true; v.className='thumb'; return v; }
 function linkifyText(str){ const url=/https?:\/\/[^\s]+/g; const frag=document.createDocumentFragment(); let last=0; str=String(str||''); let m; while((m=url.exec(str))){ if(m.index>last) frag.appendChild(document.createTextNode(str.slice(last,m.index))); const a=document.createElement('a'); a.href=m[0]; a.target='_blank'; a.textContent=m[0]; frag.appendChild(a); last=m.index+m[0].length; } if(last<str.length) frag.appendChild(document.createTextNode(str.slice(last))); return frag; }
 
 // ===== Media pickers (question/comment) =====
-let qImgData='', qAudData='', cImgData='', cAudData='';
+let qImgData='', qAudData='', qVidData='', cImgData='', cAudData='', cVidData='';
 const qImg=document.getElementById('qImg'), qImgPick=document.getElementById('qImgPick'), qImgPrev=document.getElementById('qImgPrev'), qImgClear=document.getElementById('qImgClear');
 qImgPick.onclick=()=>qImg.click();
 qImg.onchange=async e=>{ const f=e.target.files?.[0]; if(!f) return; qImgData=await fileToDataURL(f); qImgPrev.src=qImgData; qImgPrev.style.display='block'; qImgClear.style.display='inline-block'; };
+  qAudMini.innerHTML=''; qAudMini.style.display='none'; qAudClear.style.display='none';
 qImgClear.onclick=()=>{ qImg.value=''; qImgData=''; qImgPrev.style.display='none'; qImgClear.style.display='none'; };
 const qAud=document.getElementById('qAud'), qAudPick=document.getElementById('qAudPick'), qAudMini=document.getElementById('qAudMini'), qAudClear=document.getElementById('qAudClear');
 qAudPick.onclick=()=>qAud.click();
 qAud.onchange=async e=>{ const f=e.target.files?.[0]; if(!f) return; qAudData=await fileToDataURL(f); qAudMini.innerHTML=''; qAudMini.appendChild(miniAudio(qAudData,'Audio')); qAudMini.style.display='inline-flex'; qAudClear.style.display='inline-block'; };
 qAudClear.onclick=()=>{ qAud.value=''; qAudData=''; qAudMini.innerHTML=''; qAudMini.style.display='none'; qAudClear.style.display='none'; };
+const qVid=document.getElementById('qVid'), qVidPick=document.getElementById('qVidPick'), qVidMini=document.getElementById('qVidMini'), qVidClear=document.getElementById('qVidClear');
+qVidPick.onclick=()=>qVid.click();
+qVid.onchange=async e=>{ const f=e.target.files?.[0]; if(!f) return; qVidData=await fileToDataURL(f); qVidMini.innerHTML=''; qVidMini.appendChild(miniVideo(qVidData)); qVidMini.style.display='inline-flex'; qVidClear.style.display='inline-block'; };
+qVidClear.onclick=()=>{ qVid.value=''; qVidData=''; qVidMini.innerHTML=''; qVidMini.style.display='none'; qVidClear.style.display='none'; };
 const cImg=document.getElementById('cImg'), cImgPick=document.getElementById('cImgPick'), cImgPrev=document.getElementById('cImgPrev'), cImgClear=document.getElementById('cImgClear');
 cImgPick.onclick=()=>cImg.click();
 cImg.onchange=async e=>{ const f=e.target.files?.[0]; if(!f) return; cImgData=await fileToDataURL(f); cImgPrev.src=cImgData; cImgPrev.style.display='block'; cImgClear.style.display='inline-block'; };
+  cAudMini.innerHTML=''; cAudMini.style.display='none'; cAudClear.style.display='none';
 cImgClear.onclick=()=>{ cImg.value=''; cImgData=''; cImgPrev.style.display='none'; cImgClear.style.display='none'; };
 const cAud=document.getElementById('cAud'), cAudPick=document.getElementById('cAudPick'), cAudMini=document.getElementById('cAudMini'), cAudClear=document.getElementById('cAudClear');
 cAudPick.onclick=()=>cAud.click();
 cAud.onchange=async e=>{ const f=e.target.files?.[0]; if(!f) return; cAudData=await fileToDataURL(f); cAudMini.innerHTML=''; cAudMini.appendChild(miniAudio(cAudData,'Audio')); cAudMini.style.display='inline-flex'; cAudClear.style.display='inline-block'; };
 cAudClear.onclick=()=>{ cAud.value=''; cAudData=''; cAudMini.innerHTML=''; cAudMini.style.display='none'; cAudClear.style.display='none'; };
+const cVid=document.getElementById('cVid'), cVidPick=document.getElementById('cVidPick'), cVidMini=document.getElementById('cVidMini'), cVidClear=document.getElementById('cVidClear');
+cVidPick.onclick=()=>cVid.click();
+cVid.onchange=async e=>{ const f=e.target.files?.[0]; if(!f) return; cVidData=await fileToDataURL(f); cVidMini.innerHTML=''; cVidMini.appendChild(miniVideo(cVidData)); cVidMini.style.display='inline-flex'; cVidClear.style.display='inline-block'; };
+cVidClear.onclick=()=>{ cVid.value=''; cVidData=''; cVidMini.innerHTML=''; cVidMini.style.display='none'; cVidClear.style.display='none'; };
 
 // ===== Editor renderers =====
 const optHost = document.getElementById('questionOptionsContainer');
@@ -385,7 +407,7 @@ function slugFromLabel(str){
     .replace(/^-+|-+$/g,'') || 'cat';
 }
 
-// Rebuilds the <select id="categorySelect">; adds a "New…" option that opens inline UI
+// Rebuilds the <select id="categorySelect">; adds a "NewÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¦" option that opens inline UI
 function renderCategorySelect(){
   const sel = document.getElementById('categorySelect');
   const ui  = document.getElementById('categoryNewUI');
@@ -394,17 +416,17 @@ function renderCategorySelect(){
   const prev = sel.value;
   sel.innerHTML = '';
 
-  const noneLbl = settings.lang==='de'?'— keine —':'— none —';
+  const noneLbl = settings.lang==='de'?'ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ keine ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ':'ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ none ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ';
   sel.appendChild(new Option(noneLbl,''));
   (meta.categories||[]).forEach(c=>{
     sel.appendChild(new Option(c.label||c.id, c.id));
   });
-  sel.appendChild(new Option('➕ '+(settings.lang==='de'?'Neu…':'New…'),'__new__'));
+  sel.appendChild(new Option('ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ '+(settings.lang==='de'?'NeuÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¦':'NewÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¦'),'__new__'));
 
   // restore previous selection if still present
   if(prev && [...sel.options].some(o=>o.value===prev)) sel.value = prev;
 
-  // hook: show inline creator when "New…" is chosen
+  // hook: show inline creator when "NewÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¦" is chosen
   sel.onchange = ()=>{
     if(sel.value === '__new__'){
       showNewCategoryUI();
@@ -479,7 +501,7 @@ function renderCategoriesManager(){
     const hintIn = el('input',{type:'text',value:c.hint||'',placeholder:lang==='de'?'Hinweis (optional)':'Hint (optional)',style:'flex:1;width:auto'});
     const del  = el('button',{className:'btn btn-ghost',title:lang==='de'?'Entfernen':'Remove',onclick:()=>{
       meta.categories.splice(idx,1); saveMeta(); renderCategoriesManager(); renderCategorySelect();
-    }},'🗑️');
+    }},'ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¯ÃÂÃÂÃÂÃÂ¸ÃÂÃÂÃÂÃÂ');
 
     idIn.oninput = ()=>{ c.id = idIn.value.trim(); saveMeta(); renderCategorySelect(); };
     labelIn.oninput = ()=>{ c.label = labelIn.value; saveMeta(); renderCategorySelect(); };
@@ -489,7 +511,7 @@ function renderCategoriesManager(){
     list.appendChild(row);
   });
 
-  const add = el('button',{className:'btn'}, '➕ '+(lang==='de'?'Kategorie hinzufügen':'Add category'));
+  const add = el('button',{className:'btn'}, 'ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ '+(lang==='de'?'Kategorie hinzufÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¼gen':'Add category'));
   add.onclick = ()=>{
     meta.categories.push({ id: slugFromLabel('Category '+((meta.categories?.length||0)+1)), label:'', hint:'' });
     saveMeta(); renderCategoriesManager(); renderCategorySelect();
@@ -506,9 +528,9 @@ function mediaPickers(hostRow, init={}){
   const iFile=el('input',{type:'file',accept:'image/*',style:'display:none'});
   const aFile=el('input',{type:'file',accept:'audio/*',style:'display:none'});
   const vFile=el('input',{type:'file',accept:'video/*',style:'display:none'});
-  const iBtn=el('button',{className:'chip',type:'button'},'🖼️');
-  const aBtn=el('button',{className:'chip',type:'button'},'🔈');
-  const vBtn=el('button',{className:'chip',type:'button'},'📹');
+  const iBtn=el('button',{className:'chip',type:'button'},'ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¼ÃÂÃÂÃÂÃÂ¯ÃÂÃÂÃÂÃÂ¸ÃÂÃÂÃÂÃÂ');
+  const aBtn=el('button',{className:'chip',type:'button'},'ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ');
+  const vBtn=el('button',{className:'chip',type:'button'},'ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¹');
   const prev=el('span',{});
   if(init.image){ prev.appendChild(el('img',{src:init.image,className:'thumb'})); hostRow.dataset.img=init.image; }
   if(init.audio){ prev.appendChild(miniAudio(init.audio,'Audio')); hostRow.dataset.aud=init.audio; }
@@ -561,32 +583,32 @@ function renderOptionsEditor(data={}){
     const list=el('div',{id:'answersList'});
     const src=(data.answers&&data.answers.length? data.answers : [{text:''},{text:''},{text:''}]);
     src.forEach((ans,i)=> list.appendChild(answerRow(type, ans, i, data)) );
-    const addBtn=el('button',{className:'btn',onclick:()=> list.appendChild(answerRow(type,{text:''}, list.querySelectorAll('.arow').length, data))}, '➕ Add answer');
+    const addBtn=el('button',{className:'btn',onclick:()=> list.appendChild(answerRow(type,{text:''}, list.querySelectorAll('.arow').length, data))}, 'ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ Add answer');
     optHost.append(list, addBtn, el('div',{className:'muted'}, type==='single'?'Mark one correct.':'Mark all correct.'));
   }
   if(type==='text'){
     const list=el('div',{id:'txtAccept'});
     const src=(data.acceptable&&data.acceptable.length? data.acceptable : [{text:''}] );
     src.forEach(v=> list.appendChild(textRow(v)) );
-    const add=el('button',{className:'btn',onclick:()=> list.appendChild(textRow({text:''}))}, '➕ Add acceptable');
+    const add=el('button',{className:'btn',onclick:()=> list.appendChild(textRow({text:''}))}, 'ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ Add acceptable');
     optHost.append(el('div',{className:'muted'},'Answers are compared using the Text Matching settings.'), list, add);
   }
   if(type==='multitext'){
     const list=el('div',{id:'multiPrompts'});
     (data.prompts&&data.prompts.length?data.prompts:[{text:'Answer 1'},{text:'Answer 2'}]).forEach(lbl=> list.appendChild(textRow(lbl)) );
-    const add=el('button',{className:'btn',onclick:()=> list.appendChild(textRow({text:''}))}, '➕ Add field');
+    const add=el('button',{className:'btn',onclick:()=> list.appendChild(textRow({text:''}))}, 'ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ Add field');
     optHost.append(el('div',{className:'muted'},'Player must fill all fields.'), list, add);
   }
   if(type==='matching'){
     const wrap=el('div',{id:'pairsWrap'});
     (data.pairs&&data.pairs.length? data.pairs : [{left:{text:''},right:{text:''}}]).forEach(p=> wrap.appendChild(pairRow(p)) );
-    const add=el('button',{className:'btn',onclick:()=> wrap.appendChild(pairRow({left:{text:''},right:{text:''}}))}, '➕ Add pair');
+    const add=el('button',{className:'btn',onclick:()=> wrap.appendChild(pairRow({left:{text:''},right:{text:''}}))}, 'ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ Add pair');
     optHost.append(el('div',{className:'muted'},'In play, drag RIGHT to match LEFT.'), wrap, add);
   }
   if(type==='order'){
     const list=el('div',{id:'orderList'});
     (data.sequence&&data.sequence.length? data.sequence : [{text:''},{text:''}]).forEach(it=> list.appendChild(orderRow(it)) );
-    const add=el('button',{className:'btn',onclick:()=> list.appendChild(orderRow({text:''}))}, '➕ Add item');
+    const add=el('button',{className:'btn',onclick:()=> list.appendChild(orderRow({text:''}))}, 'ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ Add item');
     optHost.append(el('div',{className:'muted'},'Correct order is the list order here.'), list, add);
   }
 }
@@ -597,7 +619,7 @@ renderOptionsEditor();
 // Gather editor data
 function collectQuestion(){
   const type=qTypeSel.value; const question=document.getElementById('questionText').value.trim();
-  const q={type, question, questionMedia:{image:qImgData||'', audio:qAudData||''}, comment:(document.getElementById('questionComment').value||'').trim(), commentMedia:{image:cImgData||'', audio:cAudData||''}};
+  const q={type, question, questionMedia:{image:qImgData||'', audio:qAudData||'', video:qVidData||''}, comment:(document.getElementById('questionComment').value||'').trim(), commentMedia:{image:cImgData||'', audio:cAudData||'', video:cVidData||''}};
   const catSel=document.getElementById('categorySelect'); if(catSel && catSel.value) q.categoryId=catSel.value;
   if(type==='single' || type==='multiple'){
     const rows=[...optHost.querySelectorAll('#answersList .arow')];
@@ -635,11 +657,13 @@ function collectQuestion(){
 function loadIntoEditor(q){
   document.getElementById('questionText').value=q.question||'';
   document.getElementById('questionComment').value=q.comment||'';
-  qImgData=q.questionMedia?.image||''; qAudData=q.questionMedia?.audio||''; cImgData=q.commentMedia?.image||''; cAudData=q.commentMedia?.audio||'';
+  qImgData=q.questionMedia?.image||''; qAudData=q.questionMedia?.audio||''; qVidData=q.questionMedia?.video||''; cImgData=q.commentMedia?.image||''; cAudData=q.commentMedia?.audio||''; cVidData=q.commentMedia?.video||'';
   if(qImgData){ qImgPrev.src=qImgData; qImgPrev.style.display='block'; qImgClear.style.display='inline-block'; } else { qImgPrev.style.display='none'; qImgClear.style.display='none'; }
   if(qAudData){ qAudMini.innerHTML=''; qAudMini.appendChild(miniAudio(qAudData,'Audio')); qAudMini.style.display='inline-flex'; qAudClear.style.display='inline-block'; } else { qAudMini.innerHTML=''; qAudMini.style.display='none'; qAudClear.style.display='none'; }
+  if(qVidData){ qVidMini.innerHTML=""; qVidMini.appendChild(miniVideo(qVidData)); qVidMini.style.display="inline-flex"; qVidClear.style.display="inline-block"; } else { qVidMini.innerHTML=""; qVidMini.style.display="none"; qVidClear.style.display="none"; }
   if(cImgData){ cImgPrev.src=cImgData; cImgPrev.style.display='block'; cImgClear.style.display='inline-block'; } else { cImgPrev.style.display='none'; cImgClear.style.display='none'; }
   if(cAudData){ cAudMini.innerHTML=''; cAudMini.appendChild(miniAudio(cAudData,'Audio')); cAudMini.style.display='inline-flex'; cAudClear.style.display='inline-block'; } else { cAudMini.innerHTML=''; cAudMini.style.display='none'; cAudClear.style.display='none'; }
+  if(cVidData){ cVidMini.innerHTML=""; cVidMini.appendChild(miniVideo(cVidData)); cVidMini.style.display="inline-flex"; cVidClear.style.display="inline-block"; } else { cVidMini.innerHTML=""; cVidMini.style.display="none"; cVidClear.style.display="none"; }
   qTypeSel.value=q.type||'single'; renderOptionsEditor(q);
   renderCategorySelect(); if(q.categoryId){ const sel=document.getElementById('categorySelect'); if(sel) sel.value=q.categoryId; }
 }
@@ -647,17 +671,20 @@ function loadIntoEditor(q){
 function clearEditorFields(){
   document.getElementById('questionText').value='';
   document.getElementById('questionComment').value='';
-  qImg.value=''; qAud.value=''; cImg.value=''; cAud.value='';
-  qImgData=qAudData=cImgData=cAudData='';
+  qImg.value=''; qAud.value=''; qVid.value=''; cImg.value=''; cAud.value=''; cVid.value='';
+  qImgData=qAudData=qVidData=cImgData=cAudData=cVidData='';
   qImgPrev.style.display='none'; qImgClear.style.display='none';
   qAudMini.innerHTML=''; qAudMini.style.display='none'; qAudClear.style.display='none';
+  qVidMini.innerHTML=''; qVidMini.style.display='none'; qVidClear.style.display='none';
   cImgPrev.style.display='none'; cImgClear.style.display='none';
   cAudMini.innerHTML=''; cAudMini.style.display='none'; cAudClear.style.display='none';
+  cVidMini.innerHTML=''; cVidMini.style.display='none'; cVidClear.style.display='none';
   const sel=document.getElementById('categorySelect'); if(sel) sel.value='';
   qTypeSel.value='single';
   renderOptionsEditor();
   editingIndex=-1;
 }
+
 
 function showEditorForm(){
   document.getElementById('editorForm').style.display='block';
@@ -677,17 +704,17 @@ function renderQuestionList(){
     const title=el('span',{className:'q-title'}, q.question||'(untitled)');
     content.append(title);
     if(q.questionMedia?.image){ content.appendChild(el('img',{src:q.questionMedia.image,className:'tiny-thumb'})); }
-    if(q.questionMedia?.audio){ content.appendChild(el('span',{className:'media-icon'},'🔈')); }
+        if(q.questionMedia?.video){ content.appendChild(el('span',{className:'media-icon'},'Ã°ÂÂÂ¹')); }
     li.append(content);
     const actions=el('div',{className:'question-actions'});
-    const edit=el('button',{},'✏️');
+    const edit=el('button',{},'ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¯ÃÂÃÂÃÂÃÂ¸ÃÂÃÂÃÂÃÂ');
     edit.onclick=()=>{
       editingIndex=i;
       loadIntoEditor(q);
       showEditorForm();
       document.getElementById('editor').scrollIntoView({behavior:'smooth'});
     };
-    const del=el('button',{},'🗑️'); del.onclick=()=>{ questions.splice(i,1); localStorage.setItem('quizData', JSON.stringify(questions)); renderQuestionList(); };
+    const del=el('button',{},'ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¯ÃÂÃÂÃÂÃÂ¸ÃÂÃÂÃÂÃÂ'); del.onclick=()=>{ questions.splice(i,1); localStorage.setItem('quizData', JSON.stringify(questions)); renderQuestionList(); };
     actions.append(edit,del); li.append(actions); ul.append(li);
   });
   // drag reorder
@@ -706,9 +733,9 @@ document.getElementById('saveQuestion').onclick=()=>{
   const q=collectQuestion();
   if(q.type==='single'&& (q.correct==null||q.correct<0)) { alert(lang==='de'?'Markiere die richtige Antwort':'Mark the correct answer'); return; }
   if(q.type==='multiple'&& (!q.corrects||!q.corrects.length)) { alert(lang==='de'?'Markiere mindestens eine richtige':'Mark at least one correct'); return; }
-  if(q.type==='text'&& (!q.acceptable||!q.acceptable.length)) { alert(lang==='de'?'Füge mindestens eine akzeptierte Antwort hinzu':'Add at least one acceptable'); return; }
-  if(q.type==='matching'&& (!q.pairs||!q.pairs.length)) { alert(lang==='de'?'Füge mindestens ein Paar hinzu':'Add at least one pair'); return; }
-  if(q.type==='order'&& (!q.sequence||q.sequence.length<2)) { alert(lang==='de'?'Füge mindestens zwei Elemente hinzu':'Add at least two items'); return; }
+  if(q.type==='text'&& (!q.acceptable||!q.acceptable.length)) { alert(lang==='de'?'FÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¼ge mindestens eine akzeptierte Antwort hinzu':'Add at least one acceptable'); return; }
+  if(q.type==='matching'&& (!q.pairs||!q.pairs.length)) { alert(lang==='de'?'FÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¼ge mindestens ein Paar hinzu':'Add at least one pair'); return; }
+  if(q.type==='order'&& (!q.sequence||q.sequence.length<2)) { alert(lang==='de'?'FÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¼ge mindestens zwei Elemente hinzu':'Add at least two items'); return; }
   q.comment=document.getElementById('questionComment').value.trim();
   if(editingIndex>=0){ questions[editingIndex]=q; }
   else questions.push(q);
@@ -811,7 +838,7 @@ document.getElementById('tab-settings').onclick=()=>{ showTab('settings'); };
     }
     meta.categories = (meta.categories||[]).map(c=> c.label? c : {id:c.id, label:(c.labels?.en||c.labels?.de||c.id), hint:c.hint||''});
     localStorage.setItem('quizData', JSON.stringify(questions)); localStorage.setItem('quizMeta', JSON.stringify(meta));
-    renderQuestionList(); renderCategorySelect(); renderCategoriesManager(); alert('Imported ✓'); }catch(err){ alert('Import failed: '+err.message); } }; r.readAsText(f); };
+    renderQuestionList(); renderCategorySelect(); renderCategoriesManager(); alert('Imported ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ'); }catch(err){ alert('Import failed: '+err.message); } }; r.readAsText(f); };
   }
   if(exportBtn){ exportBtn.onclick=()=>{ const payload={ categories: meta.categories, questions }; const blob=new Blob([JSON.stringify(payload,null,2)],{type:'application/json'}); const a=document.createElement('a'); a.href=URL.createObjectURL(blob); a.download='quiz.json'; a.click(); }; }
 })();
@@ -837,10 +864,10 @@ function showCurrent(){
   qc.innerHTML=''; qctrl.innerHTML='';
   if(__playState.timerId){ clearInterval(__playState.timerId); __playState.timerId=null; }
   const q=__playState.pool[__playState.idx]; if(!q){ finalize(); return; }
-  if(settings.showCategory && q.categoryId){ const cat=(meta.categories||[]).find(c=>c.id===q.categoryId); if(cat){ const wrap=el('div',{className:'muted'}, cat.label||cat.id); if(cat.hint){ const hb=el('button',{className:'chip',type:'button'},'💡'); const ht=el('span',{className:'muted',style:'display:none;margin-left:6px'},cat.hint); hb.onclick=()=>{ ht.style.display=ht.style.display==='none'?'inline':'none'; }; wrap.append(' ',hb,ht); } qc.appendChild(wrap); } }
+  if(settings.showCategory && q.categoryId){ const cat=(meta.categories||[]).find(c=>c.id===q.categoryId); if(cat){ const wrap=el('div',{className:'muted'}, cat.label||cat.id); if(cat.hint){ const hb=el('button',{className:'chip',type:'button'},'ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¡'); const ht=el('span',{className:'muted',style:'display:none;margin-left:6px'},cat.hint); hb.onclick=()=>{ ht.style.display=ht.style.display==='none'?'inline':'none'; }; wrap.append(' ',hb,ht); } qc.appendChild(wrap); } }
   const title=el('h3',{}, q.question); title.onclick=()=>speak(q.question); qc.appendChild(title); if(settings.autoTTSQuestions) speak(q.question);
   if(q.questionMedia?.image){ qc.appendChild(el('img',{src:q.questionMedia.image,className:'thumb'})); }
-  if(q.questionMedia?.audio){ qc.appendChild(miniAudio(q.questionMedia.audio,'Question audio')); }
+    if(q.questionMedia?.video){ qc.appendChild(miniVideo(q.questionMedia.video)); }
 
   if(q.type==='single') renderPlaySingle(q, qc, qctrl);
   else if(q.type==='multiple') renderPlayMultiple(q, qc, qctrl);
@@ -850,12 +877,12 @@ function showCurrent(){
   else if(q.type==='multitext') renderPlayMultiText(q, qc, qctrl);
   if(settings.timeLimitSec>0){
     let remaining=settings.timeLimitSec;
-    const tEl=el('div',{id:'timer'}, '⏱ '+remaining);
+    const tEl=el('div',{id:'timer'}, 'ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ± '+remaining);
     qc.prepend(tEl);
     __playState.timerId=setInterval(()=>{
       remaining--;
       const elT=document.getElementById('timer');
-      if(elT) elT.textContent='⏱ '+remaining;
+      if(elT) elT.textContent='ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ± '+remaining;
       if(remaining<=0){
         clearInterval(__playState.timerId); __playState.timerId=null;
         proceed(false, q, t('time'));
@@ -876,7 +903,7 @@ function proceed(ok, q, msg='', opts={}){
       const corr=describeCorrect(q);
       if(corr){ b.appendChild(el('div',{className:'muted'}, corr)); }
     }
-    if(settings.showComments && (q.comment || q.commentMedia?.image || q.commentMedia?.audio)){ const c=el('div',{className:'muted'}); if(q.comment){ if(settings.linkifyComments) c.appendChild(linkifyText(q.comment)); else c.textContent=q.comment; } if(q.commentMedia?.image) c.appendChild(el('div',{}, el('img',{src:q.commentMedia.image,className:'thumb'}))); if(q.commentMedia?.audio) c.appendChild(miniAudio(q.commentMedia.audio,'Comment audio')); b.appendChild(c); }
+    if(settings.showComments && (q.comment || q.commentMedia?.image || q.commentMedia?.audio || q.commentMedia?.video)){ const c=el('div',{className:'muted'}); if(q.comment){ if(settings.linkifyComments) c.appendChild(linkifyText(q.comment)); else c.textContent=q.comment; } if(q.commentMedia?.image) c.appendChild(el('div',{}, el('img',{src:q.commentMedia.image,className:'thumb'}))); if(q.commentMedia?.audio) c.appendChild(miniAudio(q.commentMedia.audio,'Comment audio')); if(q.commentMedia?.video) c.appendChild(miniVideo(q.commentMedia.video)); b.appendChild(c); }
     qc.appendChild(b);
     qctrl.innerHTML='';
     let advanced=false;
@@ -899,16 +926,17 @@ function finalize(){
     const list=el('ul',{style:'list-style:none;padding-left:0'});
     __playState.results.forEach((r,i)=>{
       const li=el('li',{}, `${i+1}. ${r.q.question}`);
-      li.appendChild(el('span',{className:'muted'}, r.ok?' ✓':' ✗'));
+      li.appendChild(el('span',{className:'muted'}, r.ok?' ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ':' ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ'));
       const corr=describeCorrect(r.q);
       if(corr) li.appendChild(el('div',{className:'muted'}, corr));
-      if(settings.showComments && (r.q.comment || r.q.commentMedia?.image || r.q.commentMedia?.audio)){
+      if(settings.showComments && (r.q.comment || r.q.commentMedia?.image || r.q.commentMedia?.audio || r.q.commentMedia?.video)){
         const c=el('div',{className:'muted'});
         if(r.q.comment){
           if(settings.linkifyComments) c.appendChild(linkifyText(r.q.comment)); else c.textContent=r.q.comment;
         }
         if(r.q.commentMedia?.image) c.appendChild(el('div',{}, el('img',{src:r.q.commentMedia.image,className:'thumb'})));
         if(r.q.commentMedia?.audio) c.appendChild(miniAudio(r.q.commentMedia.audio,'Comment audio'));
+        if(r.q.commentMedia?.video) c.appendChild(miniVideo(r.q.commentMedia.video));
         li.appendChild(c);
       }
       list.appendChild(li);
@@ -931,13 +959,13 @@ function describeCorrect(q){
       const idxs=q.corrects||[]; const texts=idxs.map(i=> q.answers?.[i]?.text||'(media)').filter(Boolean); return (lang==='de'?'Richtige Antworten: ':'Correct answers: ')+texts.join(', ');
     }
     if(q.type==='text'){
-      const acc=q.acceptable||[]; const first=acc[0]; if(!first) return ''; const txt= typeof first==='object'? first.text : first; return (lang==='de'?'Akzeptiert: ':'Acceptable: ')+txt;
+      const acc=q.acceptable||[]; const first=acc[0]; if(!first) return ''; const txt= typeof first==='object'? first.text : first; return (lang==='de'?'Korrekte Antwort: ':'Correct answer: ')+txt;
     }
     if(q.type==='matching'){
-      const pairs=q.pairs||[]; const lines=pairs.map(p=> (p.left?.text||p.left||'(media)')+' → '+(p.right?.text||p.right||'(media)')); return (lang==='de'?'Paare: ':'Pairs: ')+lines.join(' | ');
+      const pairs=q.pairs||[]; const lines=pairs.map(p=> (p.left?.text||p.left||'(media)')+' ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ '+(p.right?.text||p.right||'(media)')); return (lang==='de'?'Paare: ':'Pairs: ')+lines.join(' | ');
     }
     if(q.type==='order'){
-      const seq=q.sequence||[]; const t=seq.map(s=> s?.text||s||'(media)'); return (lang==='de'?'Reihenfolge: ':'Order: ')+t.join(' → ');
+      const seq=q.sequence||[]; const t=seq.map(s=> s?.text||s||'(media)'); return (lang==='de'?'Reihenfolge: ':'Order: ')+t.join(' ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ ');
     }
     if(q.type==='multitext'){
       const ans=(q.prompts||[]).map(p=> (p?.text||p||'')).filter(Boolean);
@@ -958,7 +986,7 @@ function renderPlaySingle(q, qc, qctrl){
     if(a.audio) box.appendChild(miniAudio(a.audio,'Play'));
     if(a.video) box.appendChild(miniVideo(a.video));
     if(a.hint){
-      const hintBtn = el('button',{className:'chip',type:'button'},'💡');
+      const hintBtn = el('button',{className:'chip',type:'button'},'ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¡');
       const hintText = el('span',{className:'muted',style:'display:none;margin-left:6px'}, a.hint);
       hintBtn.onclick = ()=>{ hintText.style.display = (hintText.style.display==='none'?'inline':'none'); };
       box.appendChild(hintBtn);
@@ -985,7 +1013,7 @@ function renderPlayMultiple(q, qc, qctrl){
     if(a.image) row.appendChild(el('img',{src:a.image,className:'thumb'}));
     if(a.audio) row.appendChild(miniAudio(a.audio,'Play'));
     if(a.video) row.appendChild(miniVideo(a.video));
-    if(a.hint){ const hBtn=el('button',{className:'chip',type:'button'},'💡'); const hTxt=el('span',{className:'muted',style:'display:none;margin-left:6px'},a.hint); hBtn.onclick=()=>{ hTxt.style.display=hTxt.style.display==='none'?'inline':'none'; }; row.append(hBtn,hTxt); }
+    if(a.hint){ const hBtn=el('button',{className:'chip',type:'button'},'ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¡'); const hTxt=el('span',{className:'muted',style:'display:none;margin-left:6px'},a.hint); hBtn.onclick=()=>{ hTxt.style.display=hTxt.style.display==='none'?'inline':'none'; }; row.append(hBtn,hTxt); }
     if(settings.autoTTSItems && a.text) row.onclick=()=>speak(a.text);
     qc.appendChild(row);
     return chk;
@@ -1016,9 +1044,9 @@ function renderPlayText(q, qc, qctrl){
   qc.appendChild(inp);
 
   const acceptable = (q.acceptable||[]).map(a => typeof a==='string' ? {text:a, hint:''} : a);
-  const hintAll = acceptable.map(a=>a.hint).filter(Boolean).join(' · ');
+  const hintAll = acceptable.map(a=>a.hint).filter(Boolean).join(' ÃÂ· ');
   if(hintAll){
-    const hBtn = el('button',{className:'chip',type:'button'},'💡');
+    const hBtn = el('button',{className:'chip',type:'button'},'Ã°ÂÂÂ¡');
     const hTxt = el('span',{className:'muted',style:'display:none;margin-left:6px'}, hintAll);
     hBtn.onclick = ()=>{ hTxt.style.display = hTxt.style.display==='none' ? 'inline' : 'none'; };
     qc.append(hBtn,hTxt);
@@ -1026,10 +1054,13 @@ function renderPlayText(q, qc, qctrl){
 
   const check = ()=>{ const u = normalizeText(inp.value); return acceptable.some(a=> normalizeText(a.text)===u ); };
   const s = el('button',{className:'btn btn-primary'}, t('submit'));
-  s.onclick = ()=> proceed(check(), q);
+  let submitted=false;
+  const submit=()=>{ if(submitted) return; submitted=true; inp.disabled=true; s.disabled=true; proceed(check(), q); };
+  s.onclick = submit;
   qctrl.appendChild(s);
-  inp.addEventListener('keydown', e=>{ if(e.key==='Enter'){ e.preventDefault(); e.stopPropagation(); proceed(check(), q); }});
+  inp.addEventListener('keydown', e=>{ if(e.key==='Enter'){ e.preventDefault(); e.stopPropagation(); submit(); }});
 }
+
 
 function renderPlayMatching(q, qc, qctrl){
   const pairs = Array.isArray(q.pairs)? q.pairs : [];
@@ -1047,7 +1078,7 @@ function renderPlayMatching(q, qc, qctrl){
     if(obj.text) card.appendChild(el('div',{},obj.text));
     if(obj.audio) card.appendChild(miniAudio(obj.audio,'Play'));
     if(obj.video) card.appendChild(miniVideo(obj.video));
-    if(obj.hint){ const hb=el('button',{className:'chip',type:'button'},'💡'); const ht=el('span',{className:'muted',style:'display:none;margin-left:6px'},obj.hint); hb.onclick=()=>{ ht.style.display=ht.style.display==='none'?'inline':'none'; }; card.append(hb,ht); }
+    if(obj.hint){ const hb=el('button',{className:'chip',type:'button'},'ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¡'); const ht=el('span',{className:'muted',style:'display:none;margin-left:6px'},obj.hint); hb.onclick=()=>{ ht.style.display=ht.style.display==='none'?'inline':'none'; }; card.append(hb,ht); }
     leftCol.appendChild(card);
   });
 
@@ -1057,7 +1088,7 @@ function renderPlayMatching(q, qc, qctrl){
     if(it.text) li.appendChild(el('div',{},it.text));
     if(it.audio) li.appendChild(miniAudio(it.audio,'Play'));
     if(it.video) li.appendChild(miniVideo(it.video));
-    if(it.hint){ const hb=el('button',{className:'chip',type:'button'},'💡'); const ht=el('span',{className:'muted',style:'display:none;margin-left:6px'},it.hint); hb.onclick=()=>{ ht.style.display=ht.style.display==='none'?'inline':'none'; }; li.append(hb,ht); }
+    if(it.hint){ const hb=el('button',{className:'chip',type:'button'},'ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¡'); const ht=el('span',{className:'muted',style:'display:none;margin-left:6px'},it.hint); hb.onclick=()=>{ ht.style.display=ht.style.display==='none'?'inline':'none'; }; li.append(hb,ht); }
     li.draggable=true; addDragHandlers(li,rightCol); rightCol.appendChild(li);
     if(settings.autoTTSItems && it.text) li.onclick=()=>speak(it.text);
   });
@@ -1072,7 +1103,7 @@ function renderPlayOrder(q, qc, qctrl){
   const items=(q.sequence||[]).map((t,i)=> typeof t==='object'? Object.assign({key:String(i)},t) : {text:String(t||''), key:String(i)});
   const sh=shuffle(items.slice());
   const list=el('ul',{className:'sort-list'});
-  sh.forEach(it=>{ const li=el('li',{}); li.dataset.key=it.key; if(it.image) li.appendChild(el('img',{src:it.image,className:'thumb'})); if(it.text) li.appendChild(el('div',{},it.text)); if(it.audio) li.appendChild(miniAudio(it.audio,'Play')); if(it.video) li.appendChild(miniVideo(it.video)); if(it.hint){ const hb=el('button',{className:'chip',type:'button'},'💡'); const ht=el('span',{className:'muted',style:'display:none;margin-left:6px'},it.hint); hb.onclick=()=>{ ht.style.display=ht.style.display==='none'?'inline':'none'; }; li.append(hb,ht); } li.draggable=true; addDragHandlers(li,list); list.appendChild(li); if(settings.autoTTSItems && it.text) li.onclick=()=>speak(it.text); });
+  sh.forEach(it=>{ const li=el('li',{}); li.dataset.key=it.key; if(it.image) li.appendChild(el('img',{src:it.image,className:'thumb'})); if(it.text) li.appendChild(el('div',{},it.text)); if(it.audio) li.appendChild(miniAudio(it.audio,'Play')); if(it.video) li.appendChild(miniVideo(it.video)); if(it.hint){ const hb=el('button',{className:'chip',type:'button'},'ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¡'); const ht=el('span',{className:'muted',style:'display:none;margin-left:6px'},it.hint); hb.onclick=()=>{ ht.style.display=ht.style.display==='none'?'inline':'none'; }; li.append(hb,ht); } li.draggable=true; addDragHandlers(li,list); list.appendChild(li); if(settings.autoTTSItems && it.text) li.onclick=()=>speak(it.text); });
   qc.appendChild(list);
   const s=el('button',{className:'btn btn-primary'}, t('submit')); s.onclick=()=>{ const order=[...list.children].map(li=>li.dataset.key); const ok=order.every((v,i)=> v===String(i)); proceed(ok,q); }; qctrl.appendChild(s);
 }
@@ -1080,9 +1111,13 @@ function renderPlayOrder(q, qc, qctrl){
 function renderPlayMultiText(q, qc, qctrl){
   const inputs=[];
   const prompts=(q.prompts&&q.prompts.length?q.prompts:['Answer 1','Answer 2']).map(p=> typeof p==='string'? {text:p,hint:''}:p);
+  let s;
+  const check=()=> inputs.every((inp,idx)=> normalizeText(inp.value) === normalizeText(prompts[idx]?.text||''));
+  let submitted=false;
+  const submit=()=>{ if(submitted) return; submitted=true; inputs.forEach(i=>i.disabled=true); s.disabled=true; proceed(check(), q); };
   prompts.forEach((p,idx)=>{
     if(p.hint){
-      const hb=el('button',{className:'chip',type:'button'},'💡');
+      const hb=el('button',{className:'chip',type:'button'},'Ã°ÂÂÂ¡');
       const ht=el('span',{className:'muted',style:'display:none;margin-left:6px'},p.hint);
       hb.onclick=()=>{ ht.style.display=ht.style.display==='none'?'inline':'none'; };
       qc.append(hb,ht);
@@ -1097,17 +1132,17 @@ function renderPlayMultiText(q, qc, qctrl){
         if(idx<inputs.length-1){
           inputs[idx+1].focus();
         } else {
-          s.click();
+          submit();
         }
       }
     });
   });
   if(inputs[0]) inputs[0].focus();
-  const check=()=> inputs.every((inp,idx)=> normalizeText(inp.value) === normalizeText(prompts[idx]?.text||''));
-  const s=el('button',{className:'btn btn-primary'}, t('submit'));
-  s.onclick=()=> proceed(check(), q);
+  s=el('button',{className:'btn btn-primary'}, t('submit'));
+  s.onclick=submit;
   qctrl.appendChild(s);
 }
+
 function markSubmit(evalFn, qctrl, q){ const s=el('button',{className:'btn btn-primary'}, t('submit')); s.onclick=()=> proceed(!!evalFn(), q); qctrl.appendChild(s); }
 
 // Drag helpers
@@ -1128,9 +1163,9 @@ function addDragHandlers(li, list){ li.addEventListener('dragstart',e=>{ li.clas
     const iFile=el('input',{type:'file',accept:'image/*',style:'display:none'});
     const aFile=el('input',{type:'file',accept:'audio/*',style:'display:none'});
     const vFile=el('input',{type:'file',accept:'video/*',style:'display:none'});
-    const iBtn=el('button',{className:'chip',type:'button'},'🖼️'); iBtn.onclick=()=>iFile.click();
-    const aBtn=el('button',{className:'chip',type:'button'},'🔈'); aBtn.onclick=()=>aFile.click();
-    const vBtn=el('button',{className:'chip',type:'button'},'📹'); vBtn.onclick=()=>vFile.click();
+    const iBtn=el('button',{className:'chip',type:'button'},'ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¼ÃÂÃÂÃÂÃÂ¯ÃÂÃÂÃÂÃÂ¸ÃÂÃÂÃÂÃÂ'); iBtn.onclick=()=>iFile.click();
+    const aBtn=el('button',{className:'chip',type:'button'},'ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ'); aBtn.onclick=()=>aFile.click();
+    const vBtn=el('button',{className:'chip',type:'button'},'ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¹'); vBtn.onclick=()=>vFile.click();
     const preview=el('span',{});
     if(valueObj.image){ preview.appendChild(el('img',{src:valueObj.image,className:'thumb'})); row.dataset.img=valueObj.image; }
     if(valueObj.audio){ preview.appendChild(miniAudio(valueObj.audio,'Audio')); row.dataset.aud=valueObj.audio; }
@@ -1166,32 +1201,32 @@ function addDragHandlers(li, list){ li.addEventListener('dragstart',e=>{ li.clas
       const list=el('div',{id:'answersList'});
       const src = (data.answers&&data.answers.length? data.answers : [{text:''},{text:''},{text:''}]);
       src.forEach((ans,i)=> list.appendChild(buildAnswerRow(type, ans, i, data)) );
-      const addBtn = el('button',{className:'btn',onclick:()=> list.appendChild(buildAnswerRow(type,{text:''}, list.querySelectorAll('.arow').length, data))}, '➕ Add answer');
+      const addBtn = el('button',{className:'btn',onclick:()=> list.appendChild(buildAnswerRow(type,{text:''}, list.querySelectorAll('.arow').length, data))}, 'ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ Add answer');
       optHost.append(list, addBtn, el('div',{className:'muted'}, type==='single'?'Mark one correct.':'Mark all correct.'));
     }
     if(type==='text'){
       const list=el('div',{id:'txtAccept'});
       const src=(data.acceptable&&data.acceptable.length? data.acceptable : [{text:''}] );
       src.forEach(v=> list.appendChild(buildTextRow(v)) );
-      const add=el('button',{className:'btn',onclick:()=> list.appendChild(buildTextRow({text:''}))}, '➕ Add acceptable');
+      const add=el('button',{className:'btn',onclick:()=> list.appendChild(buildTextRow({text:''}))}, 'ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ Add acceptable');
       optHost.append(el('div',{className:'muted'},'Answers are compared using the Text Matching settings.'), list, add);
     }
     if(type==='multitext'){
       const list=el('div',{id:'multiPrompts'});
       (data.prompts&&data.prompts.length?data.prompts:[{text:'Answer 1'},{text:'Answer 2'}]).forEach(lbl=> list.appendChild(buildTextRow(lbl)));
-      const add=el('button',{className:'btn',onclick:()=> list.appendChild(buildTextRow({text:''}))}, '➕ Add field');
+      const add=el('button',{className:'btn',onclick:()=> list.appendChild(buildTextRow({text:''}))}, 'ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ Add field');
       optHost.append(el('div',{className:'muted'},'Player must fill all fields.'), list, add);
     }
     if(type==='matching'){
       const wrap=el('div',{id:'pairsWrap'});
       (data.pairs&&data.pairs.length? data.pairs : [{left:{text:''},right:{text:''}}]).forEach(p=> wrap.appendChild(buildPairRow(p)));
-      const add=el('button',{className:'btn',onclick:()=> wrap.appendChild(buildPairRow({left:{text:''},right:{text:''}}))}, '➕ Add pair');
+      const add=el('button',{className:'btn',onclick:()=> wrap.appendChild(buildPairRow({left:{text:''},right:{text:''}}))}, 'ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ Add pair');
       optHost.append(el('div',{className:'muted'},'In play, drag RIGHT to match LEFT. Each side can have text, image, audio, and an optional hint.'), wrap, add);
     }
     if(type==='order'){
       const list=el('div',{id:'orderList'});
       (data.sequence&&data.sequence.length? data.sequence : [{text:''},{text:''}]).forEach(it=> list.appendChild(buildOrderRow(it)) );
-      const add=el('button',{className:'btn',onclick:()=> list.appendChild(buildOrderRow({text:''}))}, '➕ Add item');
+      const add=el('button',{className:'btn',onclick:()=> list.appendChild(buildOrderRow({text:''}))}, 'ÃÂÃÂÃÂÃÂ¢ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ Add item');
       optHost.append(el('div',{className:'muted'},'The correct order is the editor order. Items can include text, image, audio, and an optional hint.'), list, add);
     }
   }
@@ -1235,7 +1270,7 @@ function addDragHandlers(li, list){ li.addEventListener('dragstart',e=>{ li.clas
   // Override collectQuestion to include hints
   window.collectQuestion = function(){
     const type=qTypeSelRef.value; const question=document.getElementById('questionText').value.trim();
-    const q={type, question, questionMedia:{image:qImgData||'', audio:qAudData||''}, comment:(document.getElementById('questionComment').value||'').trim(), commentMedia:{image:cImgData||'', audio:cAudData||''}};
+    const q={type, question, questionMedia:{image:qImgData||'', audio:qAudData||'', video:qVidData||''}, comment:(document.getElementById('questionComment').value||'').trim(), commentMedia:{image:cImgData||'', audio:cAudData||'', video:cVidData||''}};
     const catSel=document.getElementById('categorySelect'); if(catSel && catSel.value) q.categoryId=catSel.value;
     if(type==='single' || type==='multiple'){
       const rows=[...optHostRef.querySelectorAll('#answersList .arow')];
@@ -1288,8 +1323,8 @@ function addDragHandlers(li, list){ li.addEventListener('dragstart',e=>{ li.clas
     qc.appendChild(inp);
     inp.focus();
     const acceptable=(q.acceptable||[]).map(a=> typeof a==='string'? {text:a} : a);
-    const hintAll=acceptable.map(a=>a.hint).filter(Boolean).join(' · ');
-    if(hintAll){ const hBtn=el('button',{className:'chip',type:'button'},'💡'); const hTxt=el('span',{className:'muted',style:'display:none;margin-left:6px'},hintAll); hBtn.onclick=()=>{ hTxt.style.display=hTxt.style.display==='none'?'inline':'none'; }; qc.append(hBtn,hTxt); }
+    const hintAll=acceptable.map(a=>a.hint).filter(Boolean).join(' ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ· ');
+    if(hintAll){ const hBtn=el('button',{className:'chip',type:'button'},'ÃÂÃÂÃÂÃÂ°ÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂÃÂ¡'); const hTxt=el('span',{className:'muted',style:'display:none;margin-left:6px'},hintAll); hBtn.onclick=()=>{ hTxt.style.display=hTxt.style.display==='none'?'inline':'none'; }; qc.append(hBtn,hTxt); }
     const check=()=>{
       const u=normalizeText(inp.value);
       if(acceptable.some(a=> normalizeText(a.text)===u)) return {ok:true};


### PR DESCRIPTION
## Summary
- Show "Correct answer" in text feedback instead of "Acceptable"
- Disable repeated Enter submissions for text-based questions
- Add video media pickers and playback for questions and comments

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d716ad64832893ad3ff3bbbec817