### PR TITLE
Fix touch dragging and matching pair editor bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -559,13 +559,13 @@ function textRow(value){ const obj=(typeof value==='object'&&value)?value:{text:
 function pairRow(p){ const r=el('div',{className:'row pair'});
   // LEFT
   const left=el('div',{className:'row',style:'flex:1;align-items:flex-start'});
-  const lText=el('input',{type:'text',value:(p.left?.text||p.left||''),placeholder:'Left text'});
+  const lText=el('input',{type:'text',value:(typeof p.left==='object'? (p.left.text||'') : (p.left||'')),placeholder:'Left text'});
   const lHint=el('input',{type:'text',value:(p.left?.hint||''),placeholder:'Left hint (optional)'});
   const lMedia=el('span',{}); mediaPickers(lMedia,{image:p.left?.image||'',audio:p.left?.audio||'',video:p.left?.video||''}).forEach(n=>lMedia.appendChild(n));
   left.append(el('label',{},'Left'),lText,lHint,lMedia);
   // RIGHT
   const right=el('div',{className:'row',style:'flex:1;align-items:flex-start'});
-  const rText=el('input',{type:'text',value:(p.right?.text||p.right||''),placeholder:'Right text'});
+  const rText=el('input',{type:'text',value:(typeof p.right==='object'? (p.right.text||'') : (p.right||'')),placeholder:'Right text'});
   const rHint=el('input',{type:'text',value:(p.right?.hint||''),placeholder:'Right hint (optional)'});
   const rMedia=el('span',{}); mediaPickers(rMedia,{image:p.right?.image||'',audio:p.right?.audio||'',video:p.right?.video||''}).forEach(n=>rMedia.appendChild(n));
   right.append(el('label',{},'Right'),rText,rHint,rMedia);
@@ -694,6 +694,23 @@ function hideEditorForm(){
 }
 
 // Save / list
+let qTouchDrag=null;
+function addTouchDragReorder(li){
+  li.addEventListener('touchstart',()=>{ qTouchDrag=li; li.classList.add('dragging'); });
+  li.addEventListener('touchmove',e=>{
+    if(!qTouchDrag) return;
+    const t=e.touches[0];
+    const target=document.elementFromPoint(t.clientX,t.clientY)?.closest('.question-item');
+    if(target && target!==qTouchDrag && target.parentNode===li.parentNode){
+      const r=target.getBoundingClientRect();
+      const after=(t.clientY-r.top)/r.height>0.5;
+      target.parentNode.insertBefore(qTouchDrag, after?target.nextSibling:target);
+    }
+    e.preventDefault();
+  },{passive:false});
+  li.addEventListener('touchend',()=>{ li.classList.remove('dragging'); qTouchDrag=null; saveReorder(); });
+}
+
 function renderQuestionList(){
   const ul=document.getElementById('questionList'); ul.innerHTML='';
   questions.forEach((q,i)=>{
@@ -723,6 +740,7 @@ function renderQuestionList(){
     li.addEventListener('dragstart',e=>{ li.classList.add('dragging'); e.dataTransfer.effectAllowed='move'; });
     li.addEventListener('dragend',e=>{ li.classList.remove('dragging'); saveReorder(); });
     li.addEventListener('dragover',e=>{ e.preventDefault(); const t=e.currentTarget; const d=document.querySelector('.dragging'); if(d&&t!==d){ const r=t.getBoundingClientRect(); const after=(e.clientY-r.top)/r.height>0.5; t.parentNode.insertBefore(d, after?t.nextSibling:t); }});
+    addTouchDragReorder(li);
   });
 }
 renderQuestionList();
@@ -1175,7 +1193,29 @@ function renderPlayMultiText(q, qc, qctrl){
 function markSubmit(evalFn, qctrl, q){ const s=el('button',{className:'btn btn-primary'}, t('submit')); s.onclick=()=> proceed(!!evalFn(), q); qctrl.appendChild(s); }
 
 // Drag helpers
-function addDragHandlers(li, list){ li.addEventListener('dragstart',e=>{ li.classList.add('dragging-el'); e.dataTransfer.effectAllowed='move'; }); li.addEventListener('dragend',()=> li.classList.remove('dragging-el')); li.addEventListener('dragover',e=>{ e.preventDefault(); const dragging=list.querySelector('.dragging-el'); if(!dragging||dragging===li) return; const rect=li.getBoundingClientRect(); const after=(e.clientY-rect.top)>rect.height/2; list.insertBefore(dragging, after? li.nextSibling : li); }); }
+function addDragHandlers(li, list){
+  li.addEventListener('dragstart',e=>{ li.classList.add('dragging-el'); e.dataTransfer.effectAllowed='move'; });
+  li.addEventListener('dragend',()=> li.classList.remove('dragging-el'));
+  li.addEventListener('dragover',e=>{
+    e.preventDefault();
+    const dragging=list.querySelector('.dragging-el'); if(!dragging||dragging===li) return;
+    const rect=li.getBoundingClientRect(); const after=(e.clientY-rect.top)>rect.height/2;
+    list.insertBefore(dragging, after? li.nextSibling : li);
+  });
+  li.addEventListener('touchstart',()=>{ li.classList.add('dragging-el'); });
+  li.addEventListener('touchmove',e=>{
+    const dragging=list.querySelector('.dragging-el'); if(!dragging) return;
+    const t=e.touches[0];
+    const target=document.elementFromPoint(t.clientX,t.clientY)?.closest('li');
+    if(target && target!==dragging && target.parentNode===list){
+      const rect=target.getBoundingClientRect();
+      const after=(t.clientY-rect.top)>rect.height/2;
+      list.insertBefore(dragging, after? target.nextSibling : target);
+    }
+    e.preventDefault();
+  },{passive:false});
+  li.addEventListener('touchend',()=>{ li.classList.remove('dragging-el'); });
+}
 // --- Overrides: editor with hint fields, collection, and text play ---
 (function(){
   if(!window.el) return;


### PR DESCRIPTION
## Summary
- Allow touch-based drag reordering of saved questions
- Enable touch dragging for Matching and Order question play modes
- Prevent `[object Object]` text in new Matching question pairs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b20b31eca4832887e4185311a4a8e0