### PR TITLE
Remove unused validation setting and refine editor layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
   .muted{color:var(--muted)}
   .question-item{border:1px solid var(--line);background:#fff;border-radius:10px;padding:10px 100px 10px 10px;margin:8px 0;cursor:grab;position:relative;display:flex;align-items:center}
   .question-item.dragging{opacity:.7}
+  .question-item.selected{outline:2px solid var(--accent)}
   .q-title{flex:1}
   .tiny-thumb{width:24px;height:24px;object-fit:cover;margin-left:6px;border-radius:4px;vertical-align:middle}
   .media-icon{margin-left:6px;font-size:18px;vertical-align:middle}
@@ -151,8 +152,6 @@
     <label><input type="checkbox" id="showCorrectImmediate" checked> <span id="showCorrectImmediateLabel">Show correct answer when wrong (immediate)</span></label>
     <label><input type="checkbox" id="showComments" checked> <span id="showCommentsLabel">Show comments</span></label>
     <label><input type="checkbox" id="linkifyComments"> <span id="linkifyCommentsLabel">Linkify comment URLs</span></label>
-    <h3 id="validationHeading">Validation</h3>
-    <label><input type="checkbox" id="autoValidate" checked> <span id="autoValidateLabel">Validate automatically (default)</span></label>
     <h3 id="randomHeading">Random mode</h3>
     <label><input type="checkbox" id="randomMode"> <span id="randomModeLabel">Randomize questions</span></label>
     <label id="randomCountLabel">Number of questions <input type="number" id="randomCount" min="1"></label>
@@ -204,7 +203,7 @@ let settings = Object.assign({
   theme:'formal', lang:'en',
   random:false, randomCount:5, timeLimitSec:0,
   caseSensitive:false, ignorePunct:true, normalizeAccents:true, ignoreSpaces:true, regexFull:true,
-  mcqScore:'all', autoTTSQuestions:false, autoTTSItems:false, autoValidate:true,
+  mcqScore:'all', autoTTSQuestions:false, autoTTSItems:false,
   showCorrectImmediate:true,
   showCategory:false,
   allowSkip:false,
@@ -276,8 +275,6 @@ function applyLang(){
     'showCorrectImmediateLabel': lang==='de'?'Richtige Antwort anzeigen (sofort)':'Show correct answer when wrong (immediate)',
     'showCommentsLabel': lang==='de'?'Kommentare anzeigen':'Show comments',
     'linkifyCommentsLabel': lang==='de'?'Links in Kommentaren aktivieren':'Linkify comment URLs',
-    'validationHeading': lang==='de'?'Validierung':'Validation',
-    'autoValidateLabel': lang==='de'?'Automatisch prüfen (Standard)':'Validate automatically (default)',
     'randomHeading': lang==='de'?'Zufallsmodus':'Random mode',
     'randomModeLabel': lang==='de'?'Fragen zufällig anordnen':'Randomize questions',
     'randomCountLabel': lang==='de'?'Anzahl der Fragen ':'Number of questions ',
@@ -569,15 +566,20 @@ function answerRow(type, valueObj={}, idx, data){
   const txt=el('input',{type:'text',placeholder:`Answer ${idx+1}`,value:valueObj.text||''});
   const hint=el('input',{type:'text',placeholder:'Hint (optional)',value:valueObj.hint||''});
   const mediaRow=el('span',{}); mediaPickers(mediaRow,{image:valueObj.image||'',audio:valueObj.audio||'',video:valueObj.video||''}).forEach(n=>mediaRow.appendChild(n));
+  const wrap=el('div',{className:'row',style:'flex:1;align-items:flex-start'});
+  wrap.append(txt,hint,mediaRow);
   const del=el('button',{className:'btn btn-ghost',onclick:()=>row.remove()},'Remove');
-  row.append(correct,txt,hint,mediaRow,del);
+  row.append(correct,wrap,del);
   return row;
 }
 function textRow(value){
   const obj=(typeof value==='object'&&value)?value:{text:value||'',label:'',hint:''};
   const r=el('div',{className:'row'});
-  if('label' in obj){ const lbl=el('input',{type:'text',value:obj.label||'',placeholder:'Label (optional)'}); r.appendChild(lbl); }
-  const i=el('input',{type:'text',value:obj.text||'',placeholder:'Text'});
+    if('label' in obj){
+    const lbl=el('input',{type:'text',value:obj.label||'',placeholder:'Label (optional)',style:'flex:0 0 150px;width:auto'});
+    r.appendChild(lbl);
+  }
+  const i=el('input',{type:'text',value:obj.text||'',placeholder:'Text',style:'flex:1;width:auto'});
   const h=el('input',{type:'text',value:obj.hint||'',placeholder:'Hint (optional)'});
   const d=el('button',{className:'btn btn-ghost',onclick:()=>r.remove()},'Remove');
   r.append(i,h,d);
@@ -589,13 +591,13 @@ function pairRow(p){ const r=el('div',{className:'row pair'});
   const lText=el('input',{type:'text',value:(typeof p.left==='object'? (p.left.text||'') : (p.left||'')),placeholder:'Left text'});
   const lHint=el('input',{type:'text',value:(p.left?.hint||''),placeholder:'Left hint (optional)'});
   const lMedia=el('span',{}); mediaPickers(lMedia,{image:p.left?.image||'',audio:p.left?.audio||'',video:p.left?.video||''}).forEach(n=>lMedia.appendChild(n));
-  left.append(el('label',{},'Left'),lText,lHint,lMedia);
+  left.append(lText,lHint,lMedia);
   // RIGHT
   const right=el('div',{className:'row',style:'flex:1;align-items:flex-start'});
   const rText=el('input',{type:'text',value:(typeof p.right==='object'? (p.right.text||'') : (p.right||'')),placeholder:'Right text'});
   const rHint=el('input',{type:'text',value:(p.right?.hint||''),placeholder:'Right hint (optional)'});
   const rMedia=el('span',{}); mediaPickers(rMedia,{image:p.right?.image||'',audio:p.right?.audio||'',video:p.right?.video||''}).forEach(n=>rMedia.appendChild(n));
-  right.append(el('label',{},'Right'),rText,rHint,rMedia);
+  right.append(rText,rHint,rMedia);
   const del=el('button',{className:'btn btn-ghost',onclick:()=>r.remove()},'Remove');
   r.append(left,right,del);
   return r;
@@ -731,7 +733,7 @@ function hideEditorForm(){
 // Save / list
 let qTouchDrag=null;
 function addTouchDragReorder(li){
-  li.addEventListener('touchstart',()=>{ qTouchDrag=li; li.classList.add('dragging'); });
+  li.addEventListener('touchstart',()=>{ qTouchDrag=li; li.classList.add('dragging'); li.classList.add('selected'); });
   li.addEventListener('touchmove',e=>{
     if(!qTouchDrag) return;
     const t=e.touches[0];
@@ -743,7 +745,7 @@ function addTouchDragReorder(li){
     }
     e.preventDefault();
   },{passive:false});
-  li.addEventListener('touchend',()=>{ li.classList.remove('dragging'); qTouchDrag=null; saveReorder(); });
+  li.addEventListener('touchend',()=>{ li.classList.remove('dragging'); li.classList.remove('selected'); qTouchDrag=null; saveReorder(); });
 }
 
 function renderQuestionList(){
@@ -772,8 +774,8 @@ function renderQuestionList(){
   // drag reorder
   [...ul.querySelectorAll('.question-item')].forEach(li=>{
     li.draggable=true;
-    li.addEventListener('dragstart',e=>{ li.classList.add('dragging'); e.dataTransfer.effectAllowed='move'; });
-    li.addEventListener('dragend',e=>{ li.classList.remove('dragging'); saveReorder(); });
+    li.addEventListener('dragstart',e=>{ li.classList.add('dragging'); li.classList.add('selected'); e.dataTransfer.effectAllowed='move'; });
+    li.addEventListener('dragend',e=>{ li.classList.remove('dragging'); li.classList.remove('selected'); saveReorder(); });
     li.addEventListener('dragover',e=>{ e.preventDefault(); const t=e.currentTarget; const d=document.querySelector('.dragging'); if(d&&t!==d){ const r=t.getBoundingClientRect(); const after=(e.clientY-r.top)/r.height>0.5; t.parentNode.insertBefore(d, after?t.nextSibling:t); }});
     addTouchDragReorder(li);
   });
@@ -813,7 +815,7 @@ function saveReorder(){ const ul=document.getElementById('questionList'); questi
 
 // ===== Settings =====
 function applySettingsToUI(){
-  document.getElementById('feedbackImmediate').checked=settings.feedbackImmediate; document.getElementById('feedbackEnd').checked=settings.feedbackEnd; document.getElementById('showComments').checked=settings.showComments; document.getElementById('linkifyComments').checked=settings.linkifyComments; document.getElementById('autoValidate').checked=settings.autoValidate;
+  document.getElementById('feedbackImmediate').checked=settings.feedbackImmediate; document.getElementById('feedbackEnd').checked=settings.feedbackEnd; document.getElementById('showComments').checked=settings.showComments; document.getElementById('linkifyComments').checked=settings.linkifyComments;
   document.getElementById('themeSelect').value=settings.theme; document.body.setAttribute('data-theme', settings.theme);
   document.getElementById('langSelect').value=settings.lang;
   document.getElementById('randomMode').checked=settings.random; document.getElementById('randomCount').value=settings.randomCount||''; document.getElementById('timeLimitSec').value=settings.timeLimitSec||0;
@@ -846,7 +848,6 @@ document.getElementById('saveSettings').onclick=()=>{
   settings.feedbackEnd=document.getElementById('feedbackEnd').checked;
   settings.showComments=document.getElementById('showComments').checked;
   settings.linkifyComments=document.getElementById('linkifyComments').checked;
-  settings.autoValidate=document.getElementById('autoValidate').checked;
   settings.theme=document.getElementById('themeSelect').value;
   document.body.setAttribute('data-theme', settings.theme);
   settings.lang=document.getElementById('langSelect').value;
@@ -1144,6 +1145,8 @@ function renderPlayMultiple(q, qc, qctrl){
       if(settings.mcqScore==='partial_penalty') score=Math.max(0,score - wrong/total);
       ok=score>=0.999;
     }
+    checks.forEach(c=>c.disabled=true);
+    s.disabled=true;
     proceed(ok,q);
   };
   qctrl.appendChild(s);
@@ -1242,7 +1245,7 @@ function renderPlayMatching(q, qc, qctrl){
   syncHeights();
   window.addEventListener('resize', syncHeights);
   const s=el('button',{className:'btn btn-primary'}, t('submit'));
-  s.onclick=()=>{ const order=[...rightCol.children].map(li=>li.dataset.key); const ok=order.every((v,i)=> v===String(i)); proceed(ok,q); };
+  s.onclick=()=>{ const order=[...rightCol.children].map(li=>li.dataset.key); const ok=order.every((v,i)=> v===String(i)); rightCol.dataset.locked='1'; [...rightCol.children].forEach(li=>li.draggable=false); proceed(ok,q); };
   qctrl.appendChild(s);
   addKeyHandler(e=>{
     const items=[...rightCol.children];
@@ -1308,7 +1311,7 @@ function renderPlayOrder(q, qc, qctrl){
   });
   qc.appendChild(list);
   const s=el('button',{className:'btn btn-primary'}, t('submit'));
-  s.onclick=()=>{ const order=[...list.children].map(li=>li.dataset.key); const ok=order.every((v,i)=> v===String(i)); proceed(ok,q); };
+  s.onclick=()=>{ const order=[...list.children].map(li=>li.dataset.key); const ok=order.every((v,i)=> v===String(i)); list.dataset.locked='1'; [...list.children].forEach(li=>li.draggable=false); proceed(ok,q); };
   qctrl.appendChild(s);
   addKeyHandler(e=>{
     const items=[...list.children];
@@ -1374,17 +1377,19 @@ function markSubmit(evalFn, qctrl, q){ const s=el('button',{className:'btn btn-p
 
 // Drag helpers
 function addDragHandlers(li, list, onChange){
-  li.addEventListener('dragstart',e=>{ li.classList.add('dragging-el'); e.dataTransfer.effectAllowed='move'; });
-  li.addEventListener('dragend',()=>{ li.classList.remove('dragging-el'); if(onChange) onChange(); });
+  li.addEventListener('dragstart',e=>{ if(list.dataset.locked==='1'){ e.preventDefault(); return; } li.classList.add('dragging-el'); e.dataTransfer.effectAllowed='move'; });
+  li.addEventListener('dragend',()=>{ if(list.dataset.locked==='1') return; li.classList.remove('dragging-el'); if(onChange) onChange(); });
   li.addEventListener('dragover',e=>{
+    if(list.dataset.locked==='1') return;
     e.preventDefault();
     const dragging=list.querySelector('.dragging-el'); if(!dragging||dragging===li) return;
     const rect=li.getBoundingClientRect(); const after=(e.clientY-rect.top)>rect.height/2;
     list.insertBefore(dragging, after? li.nextSibling : li);
     if(onChange) onChange();
   });
-  li.addEventListener('touchstart',()=>{ li.classList.add('dragging-el'); });
+  li.addEventListener('touchstart',()=>{ if(list.dataset.locked==='1') return; li.classList.add('dragging-el'); });
   li.addEventListener('touchmove',e=>{
+    if(list.dataset.locked==='1') return;
     const dragging=list.querySelector('.dragging-el'); if(!dragging) return;
     const t=e.touches[0];
     const target=document.elementFromPoint(t.clientX,t.clientY)?.closest('li');
@@ -1396,7 +1401,7 @@ function addDragHandlers(li, list, onChange){
     }
     e.preventDefault();
   },{passive:false});
-  li.addEventListener('touchend',()=>{ li.classList.remove('dragging-el'); if(onChange) onChange(); });
+  li.addEventListener('touchend',()=>{ if(list.dataset.locked==='1') return; li.classList.remove('dragging-el'); if(onChange) onChange(); });
 }
 function updateHintInputsVisibility(){
   document.querySelectorAll('#questionOptionsContainer [data-role="hint"]').forEach(inp=>{
@@ -1429,18 +1434,20 @@ function updateHintInputsVisibility(){
     iFile.onchange=async e=>{ const f=e.target.files?.[0]; if(!f) return; const d=await fileToDataURL(f); row.dataset.img=d; const old=preview.querySelector('img'); if(old) old.remove(); preview.prepend(el('img',{src:d,className:'thumb'})); };
     aFile.onchange=async e=>{ const f=e.target.files?.[0]; if(!f) return; const d=await fileToDataURL(f); row.dataset.aud=d; const old=preview.querySelector('.chip'); if(old) old.remove(); preview.appendChild(miniAudio(d,'Audio')); };
     vFile.onchange=async e=>{ const f=e.target.files?.[0]; if(!f) return; const d=await fileToDataURL(f); row.dataset.vid=d; const old=preview.querySelector('video'); if(old) old.remove(); preview.appendChild(miniVideo(d)); };
+    const wrap=el('div',{className:'row',style:'flex:1;align-items:flex-start'});
+    wrap.append(txt,hint,iBtn,aBtn,vBtn,iFile,aFile,vFile,preview);
     const del=el('button',{className:'btn btn-ghost',onclick:()=>row.remove()},'Remove');
-    row.append(correct,txt,hint,iBtn,aBtn,vBtn,iFile,aFile,vFile,preview,del);
+    row.append(correct,wrap,del);
     return row;
   }
   function buildTextRow(obj, withLabel=false){
     const o=(typeof obj==='object'&&obj)?obj:{text:obj||'',label:'',hint:''};
     const r=el('div',{className:'row'});
     if(withLabel){
-      const lbl=el('input',{type:'text',value:o.label||'',placeholder:'Label (optional)'});
+      const lbl=el('input',{type:'text',value:o.label||'',placeholder:'Label (optional)',style:'flex:0 0 150px;width:auto'});
       r.appendChild(lbl);
     }
-    const i=el('input',{type:'text',value:o.text||'',placeholder:'Text'});
+    const i=el('input',{type:'text',value:o.text||'',placeholder:'Text',style:'flex:1;width:auto'});
     const h=el('input',{type:'text',value:o.hint||'',placeholder:'Hint (optional)'});
     h.dataset.role='hint';
     const d=el('button',{className:'btn btn-ghost',onclick:()=>r.remove()},'Remove');
@@ -1449,19 +1456,17 @@ function updateHintInputsVisibility(){
   }
   function buildPairRow(p){ const r=el('div',{className:'row pair'});
     const leftWrap=el('div',{className:'row',style:'flex:1;align-items:flex-start'});
-    const lLabel=el('label',{},'Left');
     const lText=el('input',{type:'text',value:(p.left?.text||p.left||''),placeholder:'Left text'});
     const lHint=el('input',{type:'text',value:(p.left?.hint||''),placeholder:'Left hint (optional)'});
     lHint.dataset.role='hint';
     const leftRow=el('div',{className:'row'}); leftRow.dataset.img=p.left?.image||''; leftRow.dataset.aud=p.left?.audio||''; leftRow.dataset.vid=p.left?.video||'';
-    mediaPickers(leftRow,{image:p.left?.image||'',audio:p.left?.audio||'',video:p.left?.video||''}).forEach(n=>leftRow.appendChild(n)); leftWrap.append(lLabel,lText,lHint,leftRow);
+    mediaPickers(leftRow,{image:p.left?.image||'',audio:p.left?.audio||'',video:p.left?.video||''}).forEach(n=>leftRow.appendChild(n)); leftWrap.append(lText,lHint,leftRow);
     const rightWrap=el('div',{className:'row',style:'flex:1;align-items:flex-start'});
-    const rLabel=el('label',{},'Right');
     const rText=el('input',{type:'text',value:(p.right?.text||p.right||''),placeholder:'Right text'});
     const rHint=el('input',{type:'text',value:(p.right?.hint||''),placeholder:'Right hint (optional)'});
     rHint.dataset.role='hint';
     const rightRow=el('div',{className:'row'}); rightRow.dataset.img=p.right?.image||''; rightRow.dataset.aud=p.right?.audio||''; rightRow.dataset.vid=p.right?.video||'';
-    mediaPickers(rightRow,{image:p.right?.image||'',audio:p.right?.audio||'',video:p.right?.video||''}).forEach(n=>rightRow.appendChild(n)); rightWrap.append(rLabel,rText,rHint,rightRow);
+    mediaPickers(rightRow,{image:p.right?.image||'',audio:p.right?.audio||'',video:p.right?.video||''}).forEach(n=>rightRow.appendChild(n)); rightWrap.append(rText,rHint,rightRow);
     const del=el('button',{className:'btn btn-ghost',onclick:()=>r.remove()},'Remove'); r.append(leftWrap,rightWrap,del); return r; }
   function buildOrderRow(it){ const o=(typeof it==='object'&&it)?it:{text:String(it||''),image:'',audio:'',hint:'',video:''}; const r=el('div',{className:'row order-row'}); const iText=el('input',{type:'text',value:o.text||'',placeholder:'Item text'}); const iHint=el('input',{type:'text',value:o.hint||'',placeholder:'Hint (optional)'}); iHint.dataset.role='hint'; const mediaRow=el('div',{className:'row'}); mediaRow.dataset.img=o.image||''; mediaRow.dataset.aud=o.audio||''; mediaRow.dataset.vid=o.video||''; mediaPickers(mediaRow,{image:o.image||'',audio:o.audio||'',video:o.video||''}).forEach(n=>mediaRow.appendChild(n)); const d=el('button',{className:'btn btn-ghost',onclick:()=>r.remove()},'Remove'); r.append(iText,iHint,mediaRow,d); return r; }
 


### PR DESCRIPTION
## Summary
- Remove non-functional "Validate automatically" setting and its translations
- Lock matching and ordering tiles after submit and disable MCQ checkboxes
- Highlight dragged question tiles in editor for clearer selection
- Drop left/right labels from matching editor and place single-choice radio buttons on the left
- Keep multitext label and text inputs on one line when space permits

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ea46959c83289f8e684a09801279