### PR TITLE
Add safe JSON parsing for localStorage data

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,8 +195,16 @@
 
 <script>
 // ===== State =====
-let questions = JSON.parse(localStorage.getItem('quizData')||'[]');
-let meta = Object.assign({ categories: [] }, JSON.parse(localStorage.getItem('quizMeta') || '{}'));
+function safeParse(key, fallback){
+  try{
+    const item = localStorage.getItem(key);
+    return item ? JSON.parse(item) : fallback;
+  }catch(e){
+    return fallback;
+  }
+}
+let questions = safeParse('quizData', []);
+let meta = Object.assign({ categories: [] }, safeParse('quizMeta', {}));
 meta.categories = (meta.categories || []).map(c=> ({id:c.id, label:(c.label||c.labels?.en||c.labels?.de||c.id), comment:c.comment||c.hint||''}));
 function saveMeta(){ localStorage.setItem('quizMeta', JSON.stringify(meta)); }
 let settings = Object.assign({
@@ -214,7 +222,7 @@ let settings = Object.assign({
   allowSkip:false,
   singleImmediateSubmit:true,
   showAnswerHints:false
-}, JSON.parse(localStorage.getItem('quizSettings')||'{}'));
+}, safeParse('quizSettings', {}));
 if('feedback' in settings){
   settings.feedbackImmediate = settings.feedback === 'immediate';
   settings.feedbackEnd = settings.feedback === 'end';


### PR DESCRIPTION
## Summary
- Prevent crashes from invalid localStorage JSON by introducing a `safeParse` helper
- Use `safeParse` for loading quiz data, metadata, and settings

## Testing
- `npm test` *(fails: no such file or directory, package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b48d2820208328a6edaa869185196b